### PR TITLE
Add process starter for Heroku and local

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Dynosaur
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/dynosaur`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Run a rake task in a separate process (locally or on Heroku)
 
 ## Installation
 
@@ -22,7 +20,21 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+```ruby
+Dynosaur::Client::HerokuClient.configure do |config|
+  config.app_name = '<Heroku app name>'
+  config.api_key = '<Heroku API key>'
+end
+
+dyno = Dynosaur::Process::Heroku.new(task: 'session:destroy', args: [2500])
+dyno.start
+# => run.9876
+
+local_process = Dynosaur::Process::Local.new(task: 'session:destroy', args: [2500])
+local_process.start
+# => 48345
+```
+
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,22 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+task :echo, [:arg1, :arg2] do |_task, args|
+  puts %Q(ARG1: "#{args[:arg1]}")
+  puts %Q(ARG2: "#{args[:arg2]}")
+end
+
+task :sleep, [:duration] do |_task, args|
+  File.open('/tmp/sleep', 'w') do |file|
+    file.puts "Sleeping"
+    args[:duration].to_i.times do
+      sleep(1)
+      file.print('.')
+      file.flush
+    end
+    file.print("\n")
+    file.puts "Awake"
+    file.flush
+  end
+end

--- a/dynosaur.gemspec
+++ b/dynosaur.gemspec
@@ -17,8 +17,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'platform-api'
+
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 end

--- a/lib/dynosaur.rb
+++ b/lib/dynosaur.rb
@@ -1,6 +1,7 @@
 require 'dynosaur/version'
+require 'dynosaur/process/heroku'
+require 'dynosaur/process/local'
 
 # Spin up a rake task in a separate process
 module Dynosaur
-  # Your code goes here...
 end

--- a/lib/dynosaur/client/heroku_client.rb
+++ b/lib/dynosaur/client/heroku_client.rb
@@ -1,5 +1,6 @@
 require 'platform-api'
 
+# A wrapper for the Heroku Platform API gem.
 module Dynosaur
   module Client
     module HerokuClient
@@ -22,7 +23,6 @@ module Dynosaur
       def self.api_key
         config.api_key || fail('api_key must be set in the config')
       end
-      private_class_method :api_key
 
       private
 

--- a/lib/dynosaur/client/heroku_client.rb
+++ b/lib/dynosaur/client/heroku_client.rb
@@ -1,0 +1,32 @@
+require 'platform-api'
+
+module Dynosaur
+  module Client
+    module HerokuClient
+      def self.config
+        @config ||= Config.new
+      end
+
+      def self.configure
+        yield config if block_given?
+      end
+
+      def self.client
+        PlatformAPI.connect_oauth(api_key)
+      end
+
+      def self.app_name
+        config.app_name || fail('app_name must be set in the config')
+      end
+
+      def self.api_key
+        config.api_key || fail('api_key must be set in the config')
+      end
+      private_class_method :api_key
+
+      private
+
+      Config = Struct.new(:api_key, :app_name)
+    end
+  end
+end

--- a/lib/dynosaur/process.rb
+++ b/lib/dynosaur/process.rb
@@ -1,8 +1,9 @@
 module Dynosaur
   class Process
-    def initialize(task:, args: [])
+    def initialize(task:, args: [], opts: {})
       @task = task
       @args = args
+      after_initialize(opts)
     end
 
     def start
@@ -12,6 +13,10 @@ module Dynosaur
     private
 
     attr_reader :args, :task
+
+    def after_initialize(opts)
+      # Do nothing so subclasses don't have to override if they want a no-op
+    end
 
     def rake_command
       formatted_args = args.map(&:inspect).join(',')

--- a/lib/dynosaur/process.rb
+++ b/lib/dynosaur/process.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module Dynosaur
   class Process
     def initialize(task:, args: [], opts: {})
@@ -19,7 +21,9 @@ module Dynosaur
     end
 
     def rake_command
-      formatted_args = args.map(&:inspect).join(',')
+      formatted_args = args.map do |arg|
+        arg.respond_to?(:shellescape) ? arg.shellescape : arg
+      end.join(',')
       task_with_args = args.empty? ? task : "#{task}[#{formatted_args}]"
       "rake #{task_with_args} --trace"
     end

--- a/lib/dynosaur/process.rb
+++ b/lib/dynosaur/process.rb
@@ -1,0 +1,22 @@
+module Dynosaur
+  class Process
+    def initialize(task:, args: [])
+      @task = task
+      @args = args
+    end
+
+    def start
+      fail NotImplementedError, 'This method must be implemented in a subclass'
+    end
+
+    private
+
+    attr_reader :args, :task
+
+    def rake_command
+      formatted_args = args.map(&:inspect).join(',')
+      task_with_args = args.empty? ? task : "#{task}[#{formatted_args}]"
+      "rake #{task_with_args} --trace"
+    end
+  end
+end

--- a/lib/dynosaur/process.rb
+++ b/lib/dynosaur/process.rb
@@ -22,7 +22,7 @@ module Dynosaur
 
     def rake_command
       formatted_args = args.map do |arg|
-        arg.respond_to?(:shellescape) ? arg.shellescape : arg
+        arg.is_a?(String) ? arg.shellescape : arg
       end.join(',')
       task_with_args = args.empty? ? task : "#{task}[#{formatted_args}]"
       "rake #{task_with_args} --trace"

--- a/lib/dynosaur/process/heroku.rb
+++ b/lib/dynosaur/process/heroku.rb
@@ -8,17 +8,17 @@ module Dynosaur
     class Heroku < Process
       # Valid dyno sizes under Heroku's new pricing model
       module Size
-        PERFORMANCE_M = 'performance-m'.freeze
-        PERFORMANCE_L = 'performance-l'.freeze
         STANDARD_1X = 'standard-1X'.freeze
         STANDARD_2X = 'standard-2X'.freeze
+        PERFORMANCE_M = 'performance-m'.freeze
+        PERFORMANCE_L = 'performance-l'.freeze
       end
 
       # Valid dyno sizes under Heroku's old pricing model
       module DeprecatedSize
-        PERFORMANCE = 'PX'.freeze
         STANDARD_1X = '1X'.freeze
         STANDARD_2X = '2X'.freeze
+        PERFORMANCE = 'PX'.freeze
       end
 
       def start

--- a/lib/dynosaur/process/heroku.rb
+++ b/lib/dynosaur/process/heroku.rb
@@ -1,0 +1,17 @@
+require 'dynosaur/client/heroku_client'
+
+require_relative '../process'
+
+module Dynosaur
+  class Process
+    class Heroku < Process
+      def start
+        app_name = Dynosaur::Client::HerokuClient.app_name
+        dyno_accessor = Dynosaur::Client::HerokuClient.client.dyno
+        response =
+          dyno_accessor.create(app_name, command: rake_command, attach: false)
+        response['name']
+      end
+    end
+  end
+end

--- a/lib/dynosaur/process/heroku.rb
+++ b/lib/dynosaur/process/heroku.rb
@@ -2,15 +2,40 @@ require 'dynosaur/client/heroku_client'
 
 require_relative '../process'
 
+# Start a detached rake task on a one-off dyno
 module Dynosaur
   class Process
     class Heroku < Process
+      # Valid dyno sizes under Heroku's new pricing model
+      module Size
+        PERFORMANCE_M = 'performance-m'.freeze
+        PERFORMANCE_L = 'performance-l'.freeze
+        STANDARD_1X = 'standard-1X'.freeze
+        STANDARD_2X = 'standard-2X'.freeze
+      end
+
+      # Valid dyno sizes under Heroku's old pricing model
+      module DeprecatedSize
+        PERFORMANCE = 'PX'.freeze
+        STANDARD_1X = '1X'.freeze
+        STANDARD_2X = '2X'.freeze
+      end
+
       def start
         app_name = Dynosaur::Client::HerokuClient.app_name
         dyno_accessor = Dynosaur::Client::HerokuClient.client.dyno
-        response =
-          dyno_accessor.create(app_name, command: rake_command, attach: false)
+        create_opts = { command: rake_command, attach: false }
+        create_opts[:size] = size if size
+        response = dyno_accessor.create(app_name, create_opts)
         response['name']
+      end
+
+      private
+
+      attr_reader :size
+
+      def after_initialize(opts)
+        @size = opts[:size]
       end
     end
   end

--- a/lib/dynosaur/process/local.rb
+++ b/lib/dynosaur/process/local.rb
@@ -1,0 +1,13 @@
+require_relative '../process'
+
+module Dynosaur
+  class Process
+    class Local < Process
+      def start
+        pid = ::Process.spawn(rake_command)
+        ::Process.detach(pid)
+        pid
+      end
+    end
+  end
+end

--- a/spec/dynosaur/process/heroku_spec.rb
+++ b/spec/dynosaur/process/heroku_spec.rb
@@ -1,9 +1,10 @@
 describe Dynosaur::Process::Heroku do
   describe '#start' do
-    subject { Dynosaur::Process::Heroku.new(task: task, args: args) }
+    subject { Dynosaur::Process::Heroku.new(task: task, args: args, opts: opts) }
 
     let(:task) { 'fake:task' }
     let(:args) { [] }
+    let(:opts) { {} }
 
     let(:client) { instance_double(PlatformAPI::Client, dyno: dyno_accessor) }
     let(:dyno_accessor) { instance_double(PlatformAPI::Dyno, create: api_response) }
@@ -34,6 +35,18 @@ describe Dynosaur::Process::Heroku do
         command = 'rake fake:task["Hello, World",1999] --trace'
         expect(dyno_accessor).to receive(:create)
           .with('dynosaur-test-app', command: command, attach: false)
+          .and_return(api_response)
+        subject.start
+      end
+    end
+
+    context 'when dyno size is specified' do
+      let(:opts) { { size: 'big' } }
+
+      it 'includes the dyno size' do
+        command = 'rake fake:task --trace'
+        expect(dyno_accessor).to receive(:create)
+          .with('dynosaur-test-app', command: command, attach: false, size: 'big')
           .and_return(api_response)
         subject.start
       end

--- a/spec/dynosaur/process/heroku_spec.rb
+++ b/spec/dynosaur/process/heroku_spec.rb
@@ -29,10 +29,10 @@ describe Dynosaur::Process::Heroku do
     end
 
     context 'when args are passed to the rake task' do
-      let(:args) { ['Hello, World', 1999] }
+      let(:args) { ['Hello World', 1999] }
 
       it 'adds the arguments to the rake task' do
-        command = 'rake fake:task["Hello, World",1999] --trace'
+        command = 'rake fake:task[Hello\\ World,1999] --trace'
         expect(dyno_accessor).to receive(:create)
           .with('dynosaur-test-app', command: command, attach: false)
           .and_return(api_response)

--- a/spec/dynosaur/process/heroku_spec.rb
+++ b/spec/dynosaur/process/heroku_spec.rb
@@ -1,0 +1,42 @@
+describe Dynosaur::Process::Heroku do
+  describe '#start' do
+    subject { Dynosaur::Process::Heroku.new(task: task, args: args) }
+
+    let(:task) { 'fake:task' }
+    let(:args) { [] }
+
+    let(:client) { instance_double(PlatformAPI::Client, dyno: dyno_accessor) }
+    let(:dyno_accessor) { instance_double(PlatformAPI::Dyno, create: api_response) }
+
+    let(:api_response) { { 'name' => 'run.9876' } }
+
+    before do
+      allow(PlatformAPI).to receive(:connect_oauth).with('dynosaur-test-key')
+        .and_return(client)
+    end
+
+    it 'invokes dyno.create with the rake task' do
+      command = 'rake fake:task --trace'
+      expect(dyno_accessor).to receive(:create)
+        .with('dynosaur-test-app', command: command, attach: false)
+        .and_return(api_response)
+      subject.start
+    end
+
+    it 'returns the dyno identifier' do
+      expect(subject.start).to eq('run.9876')
+    end
+
+    context 'when args are passed to the rake task' do
+      let(:args) { ['Hello, World', 1999] }
+
+      it 'adds the arguments to the rake task' do
+        command = 'rake fake:task["Hello, World",1999] --trace'
+        expect(dyno_accessor).to receive(:create)
+          .with('dynosaur-test-app', command: command, attach: false)
+          .and_return(api_response)
+        subject.start
+      end
+    end
+  end
+end

--- a/spec/dynosaur/process/local_spec.rb
+++ b/spec/dynosaur/process/local_spec.rb
@@ -1,0 +1,38 @@
+describe Dynosaur::Process::Local do
+  describe '#start' do
+    subject { Dynosaur::Process::Local.new(task: task, args: args) }
+
+    let(:task) { 'fake:task' }
+    let(:args) { [] }
+
+    before do
+      allow(Process).to receive(:spawn).and_return(38)
+      allow(Process).to receive(:detach)
+    end
+
+    it 'runs the task in a new process' do
+      command = 'rake fake:task --trace'
+      expect(Process).to receive(:spawn).with(command).and_return(38)
+      subject.start
+    end
+
+    it 'detaches from the process' do
+      expect(Process).to receive(:detach).with(38)
+      subject.start
+    end
+
+    it 'returns the process identifier' do
+      expect(subject.start).to eq(38)
+    end
+
+    context 'when args are passed to the rake task' do
+      let(:args) { ['Hello, World', 1999] }
+
+      it 'adds the arguments to the rake task' do
+        command = 'rake fake:task["Hello, World",1999] --trace'
+        expect(Process).to receive(:spawn).with(command).and_return(38)
+        subject.start
+      end
+    end
+  end
+end

--- a/spec/dynosaur/process/local_spec.rb
+++ b/spec/dynosaur/process/local_spec.rb
@@ -26,10 +26,10 @@ describe Dynosaur::Process::Local do
     end
 
     context 'when args are passed to the rake task' do
-      let(:args) { ['Hello, World', 1999] }
+      let(:args) { ['Hello World', 1999] }
 
       it 'adds the arguments to the rake task' do
-        command = 'rake fake:task["Hello, World",1999] --trace'
+        command = 'rake fake:task[Hello\\ World,1999] --trace'
         expect(Process).to receive(:spawn).with(command).and_return(38)
         subject.start
       end

--- a/spec/dynosaur_spec.rb
+++ b/spec/dynosaur_spec.rb
@@ -1,5 +1,0 @@
-describe Dynosaur do
-  it 'has a version number' do
-    expect(Dynosaur::VERSION).not_to be nil
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,8 @@ require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'dynosaur'
+
+Dynosaur::Client::HerokuClient.configure do |config|
+  config.app_name = 'dynosaur-test-app'
+  config.api_key = 'dynosaur-test-key'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'pry'
 require 'dynosaur'
 
 Dynosaur::Client::HerokuClient.configure do |config|


### PR DESCRIPTION
@kristjan @jrichard

Note: this is a _public_ repo.

Allow clients to start a rake task in either a new Heroku dyno or a local process disconnected from the current application process.

Check out the updated <a href="https://github.com/apartmentlist/dynosaur/tree/add-process-runners#dynosaur">README</a>.
