### PR TITLE
Add optional attach param to Process:Heroku

### DIFF
--- a/lib/dynosaur/process/heroku.rb
+++ b/lib/dynosaur/process/heroku.rb
@@ -23,6 +23,7 @@ module Dynosaur
         app_name = Dynosaur::Client::HerokuClient.app_name
         client = Dynosaur::Client::HerokuClient.client
         create_opts = { command: rake_command.to_s, attach: false }
+        create_opts[:attach] = attach if attach
         create_opts[:size] = size if size
         response = client.dyno.create(app_name, create_opts)
         response['name']
@@ -30,10 +31,11 @@ module Dynosaur
 
       private
 
-      attr_reader :size
+      attr_reader :size, :attach
 
       def after_initialize(opts)
         @size = opts[:size]
+        @attach = opts[:attach]
       end
     end
   end

--- a/spec/dynosaur/process/heroku_spec.rb
+++ b/spec/dynosaur/process/heroku_spec.rb
@@ -71,5 +71,17 @@ describe Dynosaur::Process::Heroku do
         subject.start
       end
     end
+
+    context 'when attach is specified' do
+      let(:opts) { { attach: true } }
+
+      it 'includes the attach setting' do
+        command = 'rake fake:task --trace'
+        expect(dyno_accessor).to receive(:create)
+          .with('dynosaur-test-app', command: command, attach: true)
+          .and_return(api_response)
+        subject.start
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, all tasks are run on a detached dyno, but we want the option
to specify. We will still default to `attach: false`, but you can now
change it in the `opts` hash on creation.