### PR TITLE
Add private dyno sizes

### DIFF
--- a/lib/dynosaur/process/heroku.rb
+++ b/lib/dynosaur/process/heroku.rb
@@ -4,12 +4,14 @@ require 'dynosaur/client/heroku_client'
 module Dynosaur
   class Process
     class Heroku < Process
-      # Valid dyno sizes under Heroku's new pricing model
       module Size
         STANDARD_1X = 'standard-1X'.freeze
         STANDARD_2X = 'standard-2X'.freeze
         PERFORMANCE_M = 'performance-m'.freeze
         PERFORMANCE_L = 'performance-l'.freeze
+        PRIVATE_S = 'Private-S'.freeze
+        PRIVATE_M = 'Private-M'.freeze
+        PRIVATE_L = 'Private-L'.freeze
       end
 
       # Valid dyno sizes under Heroku's old pricing model

--- a/lib/dynosaur/version.rb
+++ b/lib/dynosaur/version.rb
@@ -1,4 +1,4 @@
 # Gem version number
 module Dynosaur
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
Add constants for Heroku private dyno sizes for use with Heroku Enterprise accounts.

Size names pulled from here:
`curl -n https://api.heroku.com/dyno-sizes   -H "Accept: application/vnd.heroku+json; version=3"`